### PR TITLE
Create filter section

### DIFF
--- a/content/filters/additional_filters.md
+++ b/content/filters/additional_filters.md
@@ -1,0 +1,178 @@
+# Additional Filters
+
+## url_encode
+
+Encodes string as an url.
+
+#### Input
+
+~~~ liquid
+  <!-- Rental Headline = "Super Headline" -->
+    {{ rental.headline | url_encode }}
+~~~
+
+#### Output
+
+~~~
+  Super%20Headline
+~~~
+
+## rental_photo_url
+
+Insterts `img` tag with link to the given size.
+
+#### Input
+
+~~~ html
+  <img src='{{ photo | rental_photo_url: 'large' }} 1200w' >
+~~~
+
+#### Output
+
+~~~ html
+  <img src='.../image/upload/c_fill,fl_progressive,g_center,h_800,q_90,w_1200/v1436964916/uw5bsnqqbkwtxfqocbjd.jpg 1200w' >
+~~~
+
+<br>
+
+List of sizes:
+
+<br>
+<div class='tab-content' markdown='1'>
+  <div class='tab-pane active' id='public' markdown='1'>
+   Name    | Size
+:---------:|:-------:
+  compact  |  384w
+-----------|---------
+  medium   |  768w
+-----------|---------
+  large    | 1200w
+-----------|---------
+  grande   | 1536w
+-----------|---------
+  giant    | 2400w
+-----------|---------
+{: class="table table-bordered"}
+  </div>
+</div>
+
+## category_photo_url
+
+Similiar to `rental_photo_url`.
+
+## convert_stars
+
+Converts rental rating to be used as star rating.
+
+#### Input
+
+~~~ html
+  <!-- Rating = 4.8 -->
+    <span class='star-rating rating-{{ rating | convert_stars }}'><span class='sr-only'>{{ rating }}/5</span></span>
+~~~
+
+#### Output
+
+~~~ html
+  <span class='star-rating rating-100'><span class='sr-only'>4.8/5</span></span>
+~~~
+
+## iso8601
+
+Sets date or time in iso8601 format.
+
+#### Input
+
+~~~ html
+  <meta property='og:updated_time' content='{{ rental.updated_at | iso8601 }}'>
+~~~
+
+#### Output
+
+~~~ html
+  <meta property='og:updated_time' content='2015-08-16T12:42:55Z'>
+~~~
+
+## date
+
+Converts a time/date into another format.
+
+#### Input
+
+~~~ liquid
+  {{ article.published_at | date: '%a, %b %d, %y' }}
+~~~
+
+#### Output
+
+~~~
+  Tue, Apr 22, 14
+~~~
+
+> ### `date` parameters
+>
+> <br>
+>
+>  <div class='tab-content' markdown='1'>
+>    <div class='tab-pane active' id='public' markdown='1'>
+>  Paramater   | Description                   | Output
+>  :----------:|--------------------------------------------------------------------------------------------------|:-----------:
+>  %a          | Abbreviated weekday.          | Sat
+>  ------------|-------------------------------|----------------------------------------------------
+>  %A          | Full weekday name.            | Tuesday
+>  ------------|-------------------------------|----------------------------------------------------
+>  %b          | Abbreviated month name.       | Jan
+>  ------------|-------------------------------|----------------------------------------------------
+>  %B          | Full month name               | January
+>  ------------|-------------------------------|----------------------------------------------------
+>  %c          | Preferred local date and time representation      | Tue Apr 22 11:16:09 2014
+>  ------------|-------------------------------|----------------------------------------------------
+>  %d          | Day of the month, zero-padded (01, 02, 03, etc.). | 04
+>  ------------|-------------------------------|----------------------------------------------------
+>  %-d         | Day of the month, not zero-padded (1,2,3, etc.).  | 4
+>  ------------|-------------------------------|----------------------------------------------------
+>  %D          | Formats the date (dd/mm/yy).  | 04/22/14
+>  ------------|-------------------------------|----------------------------------------------------
+>  %e          | Day of the month, blank-padded ( 1, 2, 3, etc.).  | 3
+>  ------------|-------------------------------|----------------------------------------------------
+>  %F          | Returns the date in ISO 8601 format (yyyy-mm-dd). | 2014-04-22
+>  ------------|-------------------------------|----------------------------------------------------
+>  %H          | Hour of the day, 24-hour clock (00 - 23).         | 15
+>  ------------|-------------------------------|----------------------------------------------------
+>  %I          | Hour of the day, 12-hour clock (1 - 12).          | 7
+>  ------------|-------------------------------|----------------------------------------------------
+>  %j          | Day of the year (001 - 366).  | 245
+>  ------------|-------------------------------|----------------------------------------------------
+>  %k          | Hour of the day, 24-hour clock (1 - 24).          | 14
+>  ------------|-------------------------------|----------------------------------------------------
+>  %m          | Month of the year (01 - 12).  | 04
+>  ------------|-------------------------------|----------------------------------------------------
+>  %M          | Minute of the hour (00 - 59). | 53
+>  ------------|-------------------------------|----------------------------------------------------
+>  %p          | Meridian indicator (AM/PM).   | PM
+>  ------------|-------------------------------|----------------------------------------------------
+>  %r          | 12-hour time (%I:%M:%S %p)    | 03:20:07 PM
+>  ------------|-------------------------------|----------------------------------------------------
+>  %R          | 24-hour time (%H:%M)          | 15:21
+>  ------------|-------------------------------|----------------------------------------------------
+>  %T          | 24-hour time (%H:%M:%S)       | 15:22:13
+>  ------------|-------------------------------|----------------------------------------------------------------------------------------
+>  %U          | The number of the week in the current year, starting with the first Sunday as the first day of the first week. | 16
+>  ------------|-------------------------------|----------------------------------------------------------------------------------------
+>  %W          | The number of the week in the current year, starting with the first Monday as the first day of the first week. | 16
+>  ------------|-------------------------------|----------------------------------------------------------------------------------------
+>  %w          | Day of the week (0 - 6, with Sunday being 0).     | 2
+>  ------------|-------------------------------|----------------------------------------------------
+>  %x          | Preferred representation for the date alone, no time. (mm/dd/yy). | 04/22/14
+>  ------------|-------------------------------|----------------------------------------------------
+>  %X          | Preferred representation for the time. (hh:mm:ss).| 13:17:24
+>  ------------|-------------------------------|----------------------------------------------------
+>  %y          | Year without a century (00.99).                   | 14
+>  ------------|-------------------------------|----------------------------------------------------
+>  %Y          | Year with a century. | 2014
+>  ------------|-------------------------------|----------------------------------------------------
+>  %Z          | Time zone name.               | EDT
+>  ------------|-------------------------------|----------------------------------------------------
+>  {: class='table table-bordered'}
+>    </div>
+>  </div>

--- a/content/filters/array_filters.md
+++ b/content/filters/array_filters.md
@@ -1,0 +1,186 @@
+# Array Filters
+
+Array filters are used to modify the output of arrays.
+
+1. TOC
+{:toc}
+
+## join
+
+Joins the elements of an array with the character passed as the parameter. The result is a single string.
+
+#### Input
+
+~~~ liquid
+  {{ amenity.tags | join: ', ' }}
+~~~
+
+#### Output
+
+~~~
+tag1, tag2, tag3
+~~~
+
+## first
+
+Returns the first element of an array.
+
+#### Input
+
+~~~ liquid
+  <!-- amenity.tags = 'swimming pool', 'tv', 'boat', 'cellar' -->
+    {{ amenity.tags | first }}
+~~~
+
+#### Output
+
+~~~
+  swimming pool
+~~~
+
+<br>
+
+`first` can be used in dot notation, in cases where it needs to be used inside a [tag](/tags/).
+
+~~~ liquid
+  {% if amenity.tags.first == 'swimming pool' %}
+      This apartment is with a swimming pool!
+  {% endif %}
+~~~
+
+## last
+
+Gets the last element passed in an array.
+
+#### Input
+
+~~~ liquid
+  <!-- amenity.tags = 'swimming pool', 'tv', 'boat', 'cellar' -->
+    {{ amenity.tags | last }}
+~~~
+
+#### Output
+
+~~~
+cellar
+~~~
+
+<br>
+
+`last` can be used in dot notation, in cases where it needs to be used inside a [tag](/tags/).
+
+~~~ liquid
+  {% if amenity.tags.last == 'swimming pool'%}
+      This apartment is with a swimming pool!
+  {% endif %}
+~~~
+
+<br>
+
+Using `last` on a string returns the last character in the string.
+
+#### Input
+
+~~~ liquid
+  <!-- amenity.title = 'swimming pool' -->
+  {{ amenity.title | last }}
+~~~
+
+#### Output
+
+~~~
+  l
+~~~
+
+## index
+
+Returns the item at the specified index location in an array. Note that array numbering starts from zero, so the first item in an array is referenced with `[0]`.
+
+#### Input
+
+~~~ liquid
+  <!-- amenity.tags = 'swimming pool', 'tv', 'boat', 'cellar' -->
+    {{ amenity.tags[2] }}
+~~~
+
+#### Output
+
+~~~
+  boat
+~~~
+
+## map
+
+Accepts an array element's attribute as a parameter and creates a string out of each array element's value.
+
+#### Input
+
+~~~ liquid
+  <!-- collection.title = 'Spring', 'Summer', 'Fall', 'Winter' -->
+    {% assign collection_titles = collections | map: 'title' %}
+    {{ collection_titles }}
+~~~
+
+#### Output
+
+~~~
+  SpringSummerFallWinter
+~~~
+
+
+## size
+
+Returns the size of a string or an array.
+
+#### Input
+
+~~~ liquid
+  {{ '"Spring", "Summer", "Fall", "Winter"' | size }}
+~~~
+
+#### Output
+
+~~~
+  4
+~~~
+
+<br>
+
+`size` can be used in dot notation, in cases where it needs to be used inside a [tag](/tags/).
+
+~~~ liquid
+  {% if collections.frontpage.amienities.size > 10 %}
+      There are more than 10 amienities in this collection!
+  {% endif %}
+~~~
+
+## sort
+
+Sorts the elements of an array by a given attribute of an element in the array.
+
+~~~ liquid
+  {% assign amenities = collection.amenities | sort: 'title' %}
+  {% for amenity in amenities %}
+      <h4>{{ amenity.title }}</h4>
+  {% endfor %}
+~~~
+
+<br>
+
+The order of the sorted array is case-sensitive.
+
+#### Input
+
+~~~ liquid
+  <!-- amenities = 'a', 'b', 'A', 'B' -->
+    {% assign amenities = collection.amenities | sort: 'title' %}
+    {% for amenity in amenities %}
+       {{ amenity.title }}
+    {% endfor %}
+~~~
+
+#### Output
+
+~~~
+  A B a b
+~~~

--- a/content/filters/html_filters.md
+++ b/content/filters/html_filters.md
@@ -1,0 +1,115 @@
+# HTML Filters
+
+1. TOC
+{:toc}
+
+## asset_url
+
+Creates an asset url under assets_base_url.
+
+#### Input
+
+~~~ liquid
+  {{ 'images/large/' | asset_url }}
+~~~
+
+#### Output
+
+~~~ html
+  '/assets/themes/example_theme/images/large/'
+~~~
+
+## stylesheet_url
+
+Generates url for given stylesheet.
+
+#### Input
+
+~~~ liquid
+  {{ 'application.css' | stylesheet_url }}
+~~~
+
+#### Output
+
+~~~ html
+  '/assets/themes/1/stylesheets/application.css'
+~~~
+
+## stylesheet_tag
+
+Generates a stylesheet tag for given stylesheet url.
+
+#### Input
+
+~~~ liquid
+  {{ 'application.css' | stylesheet_url | stylesheet_tag }}
+~~~
+
+#### Output
+
+~~~ html
+  <link href='/assets/themes/1/stylesheets/application.css' rel='stylesheet' type='text/css'  media='all'>
+~~~
+
+## javascript_url
+
+Generates url for given script.
+
+#### Input
+
+~~~ liquid
+  {{ 'application.js' | javascript_url }}
+~~~
+
+#### Output
+
+~~~ html
+  '/assets/themes/1/javascripts/application.js'
+~~~
+
+## script_tag
+
+Generates a script tag for given script url.
+
+#### Input
+
+~~~ liquid
+  {{ 'application.js' | javascript_url | script_tag }}
+
+#### Output
+
+~~~ html
+  <script src='/assets/themes/1/javascripts/application.js' type='text/javascript'></script>
+~~~
+
+## image_url
+
+Generates image url for given image.
+
+#### Input
+
+~~~ liquid
+  {{ 'rental.jpg' | image_url }}
+~~~
+
+#### Output
+
+~~~ html
+  '/assets/themes/1/images/rental.jpg'
+~~~
+
+## img_tag
+
+Generates an image tag for given image url.
+
+#### Input
+
+~~~ liquid
+  {{ 'rental.jpg' | image_url | img_tag }}
+~~~
+
+### Output
+
+~~~ html
+  <img src='/assets/themes/1/images/rental.jpg' alt='alt'>
+~~~

--- a/content/filters/index.md
+++ b/content/filters/index.md
@@ -1,0 +1,47 @@
+# Filters
+
+Filters are simple methods that modify the output of numbers, strings, variables and objects. They are placed within an output tag `{{ }}` and are separated with a pipe character `|`.
+
+#### Input
+
+~~~ liquid
+  <!-- rental.title = 'Great Boat' -->
+    {{ rental.title | upcase }}
+~~~
+
+#### Output
+
+~~~
+  GREAT BOAT
+~~~
+
+In the example above, `rental` is an object, `title` is its attribute, and `upcase` is the filter being applied.
+
+Some filters require a parameter to be passed.
+
+#### Input
+
+~~~ liquid
+  {{ rental.title | remove: 'Great' }}
+~~~
+
+#### Output
+
+~~~
+  Boat
+~~~
+
+Multiple filters can be used on one output. They are applied from left to right.
+
+#### Input
+
+~~~ liquid
+  <!-- rental.title = 'Great Boat' -->
+    {{ rental.title | upcase | remove: 'GREAT'  }}
+~~~
+
+#### Output
+
+~~~
+  BOAT
+~~~

--- a/content/filters/markdown_filters.md
+++ b/content/filters/markdown_filters.md
@@ -1,0 +1,13 @@
+# Markdown Filters
+
+You can use markdown syntax inside rental description.
+
+## markdown_format
+
+#### Example
+
+~~~ liquid
+  {{ rental.description | markdown_format }}
+~~~
+
+To see full Markdown syntax documentation, follow this [link](http://daringfireball.net/projects/markdown/syntax).

--- a/content/filters/math_filters.md
+++ b/content/filters/math_filters.md
@@ -1,0 +1,98 @@
+# Math Filters
+
+Math filters allow you to apply mathematical tasks.
+
+Math filters can be linked and, as with any other filters, are applied in order from left to right. In the example below, `minus` is applied first, then `times`, and finally `divided_by`.
+
+~~~ liquid
+You save {{ rental.compare_at_price | minus: rental.price | times: 100.0 | divided_by: rental.compare_at_price }}%
+~~~
+
+<br>
+
+1. TOC
+{:toc}
+
+## divided_by
+
+Divides an output by a number. The output is rounded to the nearest integer.
+
+#### Input
+
+~~~ liquid
+  <!-- rental.price = 200 -->
+    {{ rental.price | divided_by: 10 }}
+~~~
+
+#### Output
+
+~~~
+  20
+~~~
+
+## minus
+
+Subtracts a number from an output.
+
+#### Input
+
+~~~ liquid
+  <!-- rental.price = 200 -->
+    {{ rental.price | minus: 15 }}
+~~~
+
+#### Output
+
+~~~
+  185
+~~~
+
+## plus
+
+Adds a number to an output.
+
+#### Input
+
+~~~ liquid
+  <!-- rental.price = 200 -->
+    {{ rental.price | plus: 15 }}
+~~~
+
+#### Output
+
+~~~
+  215
+~~~
+
+## times
+
+Multiplies an output by a number.
+
+#### Input
+
+~~~ liquid
+  <!-- rental.price = 200 -->
+    {{ rental.price | times: 1.15 }}
+~~~
+
+#### Output
+
+~~~
+  230
+~~~
+
+## modulo
+
+Divides an output by a number and returns the remainder.
+
+#### Input
+
+~~~ liquid
+  {{ 12 | modulo:5 }}
+~~~
+
+#### Output
+
+~~~
+  2
+~~~

--- a/content/filters/money_filters.md
+++ b/content/filters/money_filters.md
@@ -1,0 +1,18 @@
+# Money Filters
+
+Formats the price based on the currency formatting.
+
+1. TOC
+{:toc}
+
+#### Input
+
+~~~ html
+  <strong id='min_price_note'>{{ min_price | money: search_form.currency }}</strong>
+~~~
+
+#### Output
+
+~~~ html
+  <strong id='min_price_note'>€35</strong>
+~~~

--- a/content/filters/string_filters.md
+++ b/content/filters/string_filters.md
@@ -1,0 +1,273 @@
+# String Filters
+
+String filters are used to modify the output of strings.
+
+1. TOC
+{:toc}
+
+## append
+
+Appends characters to a string.
+
+#### Input
+
+~~~ liquid
+  {{ 'sales' | append: '.jpg' }}
+~~~
+
+#### Output
+
+~~~
+  sales.jpg
+~~~
+
+## capitalize
+
+Capitalizes the first word in a string.
+
+#### Input
+
+~~~ liquid
+  {{ 'capitalize me' | capitalize }}
+~~~
+
+#### Output
+
+~~~
+  Capitalize me
+~~~
+
+## downcase
+
+Converts a string into lowercase.
+
+
+#### Input
+
+~~~ liquid
+  {{ 'UPPERCASE' | downcase }}
+~~~
+
+#### Output
+
+~~~
+  uppercase
+~~~
+
+## escape
+
+Escapes a string.
+
+#### Input
+
+~~~ liquid
+  {{ "<p>test</p>" | escape }}
+~~~
+
+#### Output
+
+~~~ html
+  <!-- The <p> tags are not rendered -->
+    <p>test</p>
+~~~
+
+## newline_to_br
+
+Inserts a `<br>` linebreak HTML tag in front of each line break in a string.
+
+#### Input
+
+~~~ liquid
+  {% capture var %}
+  One
+  Two
+  Three
+  {% endcapture %}
+  {{ var | newline_to_br }}
+~~~
+
+#### Output
+
+~~~ html
+  One <br>
+  Two <br>
+  Three <br>
+~~~
+
+## prepend
+
+Prepends characters to a string.
+
+#### Input
+
+~~~ liquid
+  {{ 'sale' | prepend: 'Made a great ' }}
+~~~
+
+#### Output
+
+~~~
+  Made a great sale
+~~~
+
+## remove
+
+Removes all occurrences of a substring from a string.
+
+#### Input
+
+~~~ liquid
+  {{ "Hello, world. Goodbye, world." | remove: "world" }}
+~~~
+
+#### Output
+
+~~~
+  Hello, . Goodbye, .
+~~~
+
+## remove_first
+
+Removes only the first occurrence of a substring from a string.
+
+#### Input
+
+~~~ liquid
+  {{ "Hello, world. Goodbye, world." | remove_first: "world" }}
+~~~
+
+#### Output
+
+~~~
+  Hello, . Goodbye, world.
+~~~
+
+## replace
+
+Replaces all occurrences of a string with a substring.
+
+#### Input
+
+~~~ liquid
+  <!-- amenity.title = "Awesome Swimming Pool" -->
+    {{ amenity.title | replace: 'Awesome', 'Huge' }}
+~~~
+
+#### Output
+
+~~~
+  Huge Swimming Pool
+~~~
+
+## replace_first
+
+Replaces the first occurrence of a string with a substring.
+
+### Input
+
+~~~ liquid
+  <!-- product.title = "Awesome Awesome Swimming Pool" -->
+    {{ product.title | replace_first: 'Awesome', 'Huge' }}
+~~~
+
+#### Output
+
+~~~
+  Huge Awesome Swimming Pool
+~~~
+
+## split
+
+The `split` filter takes on a substring as a parameter. The substring is used as a delimiter to divide a string into an array. You can output different parts of an array using [array filters](/filters/array_filters/).
+
+#### Input
+
+~~~ liquid
+  {% assign words = "Hi, how are you today?" | split: ' ' %}
+
+  {% for word in words %}
+  {{ word }}
+  {% endfor %}
+~~~
+
+#### Output
+
+~~~
+  Hi,
+  how
+  are
+  you
+  today?
+~~~
+
+## strip_html
+
+Strips all HTML tags from a string.
+
+#### Input
+
+~~~ liquid
+  {{ "<h1>Hello</h1> World" | strip_html }}
+~~~
+
+#### Output
+
+~~~
+  Hello World
+~~~
+
+## strip_newlines
+
+Removes any line breaks/newlines from a string.
+
+~~~ liquid
+  {{ rental.description | strip_newlines }}
+~~~
+
+## truncate
+
+Truncates a string down to **'x'** characters, where **x** is the number passed as a parameter. An ellipsis (...) is appended to the string and is included in the character count.
+
+#### Input
+
+~~~ liquid
+  {{ "The cat came back the very next day" | truncate: 10 }}
+~~~
+
+#### Output
+
+~~~
+  The cat...
+~~~
+
+## truncatewords
+
+Truncates a string down to **'x'** words, where **x** is the number passed as a parameter. An ellipsis (...) is appended to the truncated string.
+
+#### Input
+
+~~~ liquid
+  {{ "The cat came back the very next day" | truncatewords: 4 }}
+~~~
+
+#### Output
+
+~~~
+  The cat came back...
+~~~
+
+## upcase
+
+Converts a string into uppercase.
+
+#### Input
+
+~~~ liquid
+  {{ 'i want this to be uppercase' | upcase }}
+~~~
+
+#### Output
+
+~~~
+  I WANT THIS TO BE UPPERCASE
+~~~

--- a/content/filters/text_filters.md
+++ b/content/filters/text_filters.md
@@ -1,0 +1,65 @@
+# Text Filters
+
+Text filters are used to manipulate text sections.
+
+1. TOC
+{:toc}
+
+## html_format
+
+Import text from Rental Description section formated with HTML tags.
+
+#### Input
+
+~~~ liquid
+  {{ rental.description | html_format }}
+~~~
+
+#### Output
+
+~~~ html
+  <p> Initial description </p>
+~~~
+
+## autolink
+
+Auto link to source social media.
+
+#### Example
+
+~~~ liquid
+  {{ site.social.twitter.last_tweet.text | autolink }}
+~~~
+
+## trim_whitespaces
+
+Trim whitespaces from input text.
+
+#### Input
+
+~~~ liquid
+  {{ ' Example String ' | trim_whitespace }}
+~~~
+
+#### Output
+
+~~~
+  'ExampleString'
+~~~
+
+## parameterize
+
+Parameterize input text.
+
+#### Input
+
+~~~ liquid
+  {{ 'rental 094 page' | parameterize }}
+~~~
+
+
+#### Output
+
+~~~
+  rental-094-page
+~~~

--- a/layouts/reference.html
+++ b/layouts/reference.html
@@ -8,6 +8,29 @@
         class: "list-group-item") %>
     </div>
     <div class="panel-heading">
+      <h3 class="panel-title">Filters</h3>
+    </div>
+    <div class="list-group">
+      <%= link_to_with_current("Introduction", "/filters/",
+        class: "list-group-item") %>
+      <%= link_to_with_current("Array Filters", "/filters/array_filters/",
+        class: "list-group-item") %>
+      <%= link_to_with_current("HTML Filters", "/filters/html_filters/",
+        class: "list-group-item") %>
+      <%= link_to_with_current("Markdown Filters", "/filters/markdown_filters/",
+        class: "list-group-item") %>
+      <%= link_to_with_current("Math Filters", "/filters/math_filters/",
+        class: "list-group-item") %>
+      <%= link_to_with_current("Money Filters", "/filters/money_filters/",
+        class: "list-group-item") %>
+      <%= link_to_with_current("String Filters", "/filters/string_filters/",
+        class: "list-group-item") %>
+      <%= link_to_with_current("Text Filters", "/filters/text_filters/",
+        class: "list-group-item") %>
+      <%= link_to_with_current("Additional Filters", "/filters/additional_filters/",
+        class: "list-group-item") %>
+    </div>
+    <div class="panel-heading">
       <h3 class="panel-title">Tags</h3>
     </div>
     <div class="list-group">


### PR DESCRIPTION
Add next docs with Filters section.

I've checked everything with Liquid docs for used version in project.
There are difference between [Shopify](https://docs.shopify.com/themes/liquid-documentation/filters) and [RubyDocs](http://www.rubydoc.info/gems/liquid/2.6.1/Liquid/StandardFilters) documentation.
What is interesting, IMHO they describe same version of liquid: `2.6.1`.
In this PR I've skipped few of Filters for safety. IMHO we could describe them anyway.
More details are in comments under [Issue on GitHub](https://huboard.com/BookingSync/BookingSync-Core#/issues/95454779).

Screencast:
![filters_section_screencast](https://cloud.githubusercontent.com/assets/218911/8976421/d0f5c8a8-368c-11e5-86c7-f77e628429e4.gif)
# Closed 192
